### PR TITLE
fix: Rework test URL query param generation

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/kotlin/KotlinClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/kotlin/KotlinClientCodegen.java
@@ -127,7 +127,9 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
     private void addSupportingFiles(boolean useRxRetrofit2) {
         if (useRxRetrofit2) {
             final String apiInfrastructureFolder = (sourceFolder + File.separator + apiPackage + File.separator + "infrastructure").replace(".", File.separator);
+            final String apiTestInfrastructureFolder = (sourceTestFolder + File.separator + apiPackage + File.separator + "infrastructure").replace(".", File.separator);
             supportingFiles.add(new SupportingFile("infrastructure/Parameters.kt.mustache", apiInfrastructureFolder, "Parameters.kt"));
+            supportingFiles.add(new SupportingFile("infrastructure/Parameters.kt.mustache", apiTestInfrastructureFolder, "Parameters.kt"));
         } else {
             final String infrastructureFolder = (sourceFolder + File.separator + packageName + File.separator + "infrastructure").replace(".", File.separator);
 

--- a/src/main/resources/handlebars/kotlin-client/api_test.mustache
+++ b/src/main/resources/handlebars/kotlin-client/api_test.mustache
@@ -15,6 +15,7 @@ import it.sky.testfoundation.core.restmockutils.matchers.body.AlwaysMatchBodyReq
 import it.sky.testfoundation.core.restmockutils.matchers.body.BodyRequestMatcher
 import it.sky.testfoundation.core.restmockutils.matchers.headers.AlwaysMatchHeadersRequestMatcher
 import it.sky.testfoundation.core.restmockutils.matchers.headers.HeadersRequestMatcher
+import {{apiPackage}}.infrastructure.*
 
 {{#operations}}
 /**
@@ -27,12 +28,14 @@ class {{classname}}URLs(private val urlBuilder: URLBuilder) {
      * Returns [RESTMockEndpointData] for [{{../classname}}.{{operationId}}]
      */
     fun {{operationId}}EndpointData(
-        {{#pathParams}}
-        {{paramName}}: {{{dataType}}}{{#or hasMore ../hasQueryParams ../hasHeaderParams ../hasBodyParam}},{{/or}}
-        {{/pathParams}}
-        {{#queryParams}}
-        {{paramName}}: {{{dataType}}}{{#or hasMore ../hasHeaderParams ../hasBodyParam}},{{/or}}
-        {{/queryParams}}
+        {{#contents}}{{#parameters}}
+        {{#isPathParam}}
+    {{>libraries/rxretrofit2/pathParams_test}}{{^required}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}{{/required}}{{#or hasMore ../hasQueryParams ../hasHeaderParams ../hasBodyParam}},{{/or}}
+        {{/isPathParam}}
+        {{#isQueryParam}}
+    {{>libraries/rxretrofit2/queryParams_test}}{{^required}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}{{/required}}{{#or hasMore ../hasHeaderParams ../hasBodyParam}},{{/or}}
+        {{/isQueryParam}}
+        {{/parameters}}{{/contents}}
         {{#hasHeaderParams}}
         headersRequestMatcher: HeadersRequestMatcher = AlwaysMatchHeadersRequestMatcher(){{#hasBodyParam}},{{/hasBodyParam}}
         {{/hasHeaderParams}}
@@ -44,9 +47,11 @@ class {{classname}}URLs(private val urlBuilder: URLBuilder) {
             RequestMatchers.pathEndsWith(
                 urlBuilder.buildUrl(
                     "{{{pathToKotlinStringTemplate path}}}"{{#hasQueryParams}},{{/hasQueryParams}}
-                    {{#queryParams}}
-                    QueryParameter("{{paramName}}", {{paramName}}){{#hasMore}},{{/hasMore}}
-                    {{/queryParams}}
+                    {{#contents}}{{#parameters}}
+                    {{#isQueryParam}}
+                    QueryParameter("{{baseName}}", {{paramName}}){{#hasMore}},{{/hasMore}}
+                    {{/isQueryParam}}
+                    {{/parameters}}{{/contents}}
                 )
             )
         )

--- a/src/main/resources/handlebars/kotlin-client/libraries/rxretrofit2/pathParams_test.mustache
+++ b/src/main/resources/handlebars/kotlin-client/libraries/rxretrofit2/pathParams_test.mustache
@@ -1,0 +1,1 @@
+{{#isPathParam}}{{paramName}}: {{{dataType}}}{{/isPathParam}}

--- a/src/main/resources/handlebars/kotlin-client/libraries/rxretrofit2/queryParams_test.mustache
+++ b/src/main/resources/handlebars/kotlin-client/libraries/rxretrofit2/queryParams_test.mustache
@@ -1,0 +1,1 @@
+{{#isQueryParam}}{{paramName}}: {{#collectionFormat}}{{#isCollectionFormatMulti}}{{{dataType}}}{{/isCollectionFormatMulti}}{{^isCollectionFormatMulti}}{{{collectionFormat.toUpperCase}}}Params{{/isCollectionFormatMulti}}{{/collectionFormat}}{{^collectionFormat}}{{{dataType}}}{{/collectionFormat}}{{/isQueryParam}}


### PR DESCRIPTION
Rework test URL query param generation to be similar to the one used in non-test classes.
Also add support for needed infrastructure files.